### PR TITLE
Add some basic TLS support via environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Usage: k <command> [options] [arguments]
 
 Environment Variables:
     KAFKA_BROKERS
+    SSL_CA_BUNDLE_PATH
+    SSL_CRT_PATH
+    SSL_KEY_PATH
 
 Commands:
     produce     produce messages to given topic

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func printOverviewUsage(w io.Writer) {
 	fmt.Fprintf(w, "Usage: k <command> [options] [arguments]\n")
 	fmt.Fprintf(w, "\nEnvironment Variables: \n")
 	fmt.Fprintf(w, "    KAFKA_BROKERS\n")
+	fmt.Fprintf(w, "    SSL_CA_BUNDLE_PATH\n")
+	fmt.Fprintf(w, "    SSL_CRT_PATH\n")
+	fmt.Fprintf(w, "    SSL_KEY_PATH\n")
 	fmt.Fprintf(w, "\nCommands:\n")
 	for _, command := range commands {
 		fmt.Fprintf(w, "    %-8s    %s\n", command.Name(), command.Short)


### PR DESCRIPTION
Somewhat of a work in progress, not working in my testing quite yet.

I'm not sure if Sarama's TLS configuration support lines up 100% with the official Kafka 0.9 implementation (https://github.com/Shopify/sarama/issues/581).

This code reads in some environment variables and configures either server-authenticated TLS (if you point `SSL_CA_BUNDLE_PATH` at a PEM bundle of CA certs) or mutually-authenticated TLS with client certificates (if you also set `SSL_CRT_PATH` and `SSL_KEY_PATH` to PEM formatted client certificate and private key).

cc @xstevens @tomwans
